### PR TITLE
Load multiple fonts on init

### DIFF
--- a/js/providers/typekit.js
+++ b/js/providers/typekit.js
@@ -57,7 +57,7 @@
 			isShimLoaded = true;
 			// clear the loading queue, if any
 			if ( toLoadInShim.length ) {
-				$.map( toLoadInShim, loadViaShim );
+				loadViaShim( toLoadInShim );
 				toLoadInShim = [];
 			}
 		});
@@ -84,9 +84,14 @@
 		// remove loading class, add loaded class
 		$html.removeClass( loadingClass ).addClass( activeClass );
 		$( '<link />', { rel: 'stylesheet', href: data.styleURL } ).appendTo( 'head' );
-		loadedFontIds.push( data.fonts[0].id );
+		$.each( data.fonts, function( i,font ){
+			loadedFontIds.push( font.id );
+		});
 	}
 
+	/**
+	 * Accepts a single `font` or an array of `font`s
+	 */
 	function loadViaShim( font ) {
 		// queue fonts if the shim hasn't loaded yet
 		if ( ! isShimLoaded ) {
@@ -101,7 +106,13 @@
 		timeout = setTimeout( function() {
 			$html.removeClass( loadingClass );
 		}, 5000 );
-		iframeHelper.contentWindow.postMessage( JSON.stringify( { type: dataType, fonts: [ font ] } ), '*' );
+
+		// Support multiple fonts. We pass in the whole toLoadInShim array when clearing it
+		// Otherwise we get a race condition on the first font if there are multiple.
+		if ( ! $.isArray( font ) ) {
+			font = [ font ];
+		}
+		iframeHelper.contentWindow.postMessage( JSON.stringify( { type: dataType, fonts: font } ), '*' );
 	};
 
 	function loadFont( font ) {


### PR DESCRIPTION
This prevents a race condition where only the `body-text` font would properly come onto the page when both saved fonts are Typekit fonts.

This is also slightly more efficient.
