### PR TITLE
Fix output of split_font_shorthand

### DIFF
--- a/typekit-theme-mock.php
+++ b/typekit-theme-mock.php
@@ -78,7 +78,11 @@ class TypekitTheme {
 			if ( !empty( $matches['style'] ) )   $parts['font-style']   = $matches['style'];
 			if ( !empty( $matches['weight'] ) )  $parts['font-weight']  = $matches['weight'];
 		}
-		return $parts;
+		$rules = array();
+		foreach( $parts as $property => $value ) {
+			array_push( $rules, array( 'property' => $property, 'value' => $value ) );
+		}
+		return $rules;
 	}
 
 }


### PR DESCRIPTION
`split_font_shorthand` was returning an associative array of property/value pairs of the form:

```
array(
  'font-size' => '18px'
);
```

...but it is being used to parse annotation declarations which are of the form:

```
array(
  array(
    'property' => 'font-size',
    'value' => '18px'
  );
);
```

So it was generating unusable data.
