### PR TITLE
Add styles for preview mode

### DIFF
--- a/css/jetpack-fonts-typekit.css
+++ b/css/jetpack-fonts-typekit.css
@@ -1,17 +1,17 @@
 .jetpack-fonts__typekit-option-logo {
-  width: 16px;
-  height: 16px;
-  margin: 15px 10px 0px 0px;
-  content: "";
-  background-repeat: no-repeat;
-  background-position: 0 0;
-  background-size: 100%;
-  display: inline-block;
-  float: right;
+	width: 16px;
+	height: 16px;
+	margin: 15px 10px 0px 0px;
+	content: "";
+	background-repeat: no-repeat;
+	background-position: 0 0;
+	background-size: 100%;
+	display: inline-block;
+	float: right;
 }
 
 .jetpack-fonts__current-font .jetpack-fonts__typekit-option-logo {
-  display: none;
+	display: none;
 }
 
 /*


### PR DESCRIPTION
Adds the little "previewing dot" to the Section when previewing the Custom Design upgrade.

![screen shot 2015-06-15 at 4 57 23 pm](https://cloud.githubusercontent.com/assets/2036909/8170572/9d14e0bc-137f-11e5-89c6-7346bda37361.png)

Part of fixing https://github.com/Automattic/custom-fonts/issues/183
