### PR TITLE
Avoid exceptions when importing legacy annotations.

### DIFF
--- a/typekit-theme-mock.php
+++ b/typekit-theme-mock.php
@@ -7,11 +7,12 @@ class TypekitTheme {
 	const CSS_FONT_VALUE_RX = '/^\s*(((?P<style>normal|italic|oblique)|(?P<variant>normal|small-caps|inherit)|(?P<weight>normal|bold|\d{3}))\s+)*(?P<size>[^\/\s]+)(?P<lineheight>\s*\/\s*[^\s]+)?\s+(?P<family>.+)$/si';
 
 	public static $rules_dependency;
+	public static $allowed_categories = array();
 
 	public static function add_font_category_rule( $category_rules, $category_id, $selector, $declarations = array(), $media_queries = array() ) {
 		$selector = preg_replace( "/[\n\t]+/", ' ', trim( $selector ) );
 
-		if ( empty( $declarations ) || 'none' === $category_id ) {
+		if ( empty( $declarations ) || ! in_array( $category_id, self::$allowed_categories ) ) {
 			return;
 		}
 

--- a/wpcom-compat.php
+++ b/wpcom-compat.php
@@ -14,6 +14,7 @@ function wpcom_font_rules_compat( $rules ) {
 		require_once __DIR__ . '/typekit-theme-mock.php';
 		include_once $annotations_file;
 		TypekitTheme::$rules_dependency = $rules;
+		TypekitTheme::$allowed_categories = $rules->get_allowed_types();
 		apply_filters( 'typekit_add_font_category_rules', array() );
 	}
 }


### PR DESCRIPTION
Sometimes they have weird categories like `placeholder` or other things that make no sense since they never did anything.

Eg: Baskerville theme will throw Exceptions in the Customizer, but won't after this.

Fixes https://github.com/Automattic/custom-fonts/issues/210
