### PR TITLE
Only publish a kit if we are not in preview mode

### DIFF
--- a/providers/typekit.php
+++ b/providers/typekit.php
@@ -131,7 +131,7 @@ class Jetpack_Typekit_Font_Provider extends Jetpack_Font_Provider {
 		}
 
 		// Avoid publishing a kit when we are only in preview mode.
-		if ( class_exists( 'CustomDesign' ) && CustomDesign::is_previewing() ) {
+		if ( class_exists( 'CustomDesign' ) && ! CustomDesign::is_upgrade_active() ) {
 			return $fonts;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/custom-fonts/issues/217

To test:
1. Using a site without Custom Design, visit the Customizer with the new plugin enabled (`?google-fonts=1`).
2. Enter the Custom Design Preview by clicking 'Try Now' in the Custom Design section.
3. **Without** this PR enabled (just using `master`), select a Typekit font from one of the lists in the Fonts section.
4. Press 'Save & Publish' button.
5. Using wp-cli, check the contents of the `jetpack_fonts` option and be sure there is a `typekit_kit_id` set for that site.
6. In the Customizer, remove all Typekit fonts and press 'Save & Publish' again to delete the saved Kit.
7. **Switching to the code in this PR**, repeat steps 3-5 again.
8. The contents of the `jetpack_fonts` option will contain the saved Typekit font under `selected_fonts`, but there should not be a `typekit_kit_id` set this time.
