### PR TITLE
Fix typekit icon overlap

### DIFF
--- a/css/jetpack-fonts-typekit.css
+++ b/css/jetpack-fonts-typekit.css
@@ -1,12 +1,13 @@
 .jetpack-fonts__typekit-option-logo {
-  width: 16px;
-  height: 16px;
-  margin: 15px 10px 0px 0px;
+  width: 32px;
+  height: 100%;
+  margin: 0;
   background: url( '../img/typekit-logo-1x.png' ) no-repeat 0 0;
-  background-size: 100%;
+  background-size: 16px;
+  background-position: center;
+  background-color: #fff;
   display: inline-block;
   float: right;
-  opacity: .5;
 }
 .jetpack-fonts__typekit-credit {
   display: inline-block;


### PR DESCRIPTION
Fixes https://github.com/Automattic/custom-fonts/issues/223

The overlap now looks like this:

<img width="241" alt="screen shot 2015-07-28 at 6 32 20 pm" src="https://cloud.githubusercontent.com/assets/2036909/8945660/5fc0cbbe-3557-11e5-92e3-13326d31f5a6.png">
