### PR TITLE
Exit early if we don't have any fonts set to avoid PHP notices.

### DIFF
--- a/typekit-shims.php
+++ b/typekit-shims.php
@@ -48,6 +48,9 @@ class TypekitData {
 			'site-title' => array( 'id' => null ),
 			'body-text' => array( 'id' => null )
 		);
+		if ( ! $fonts ) {
+			return $families;
+		}
 		foreach ( $fonts as $font ) {
 			$families[ $font['type'] ] = array(
 				'id' => $font['id'],


### PR DESCRIPTION
`$fonts` would be `false` on init. We could cas to array, but
may as well exit early for slight efficiency gain.
