### PR TITLE
Fix provider check in add_typekit_fallback_css

### DIFF
--- a/providers/typekit.php
+++ b/providers/typekit.php
@@ -98,7 +98,7 @@ class Jetpack_Typekit_Font_Provider extends Jetpack_Font_Provider {
 	}
 
 	public function add_typekit_fallback_css( $font_names, $font  ) {
-		if ( $font['provider'] === 'typekit' ) {
+		if ( $font['provider'] !== 'typekit' ) {
 			return $font_names;
 		}
 		// Typekit fallback in case the cssName is incorrect for some reason


### PR DESCRIPTION
The check was supposed to return early if the provider for a font was not typekit, but it does the reverse.

Bug added in #65 although it didn't manifest because the provider is not being included with the font.
