### PR TITLE
Retire Skolar Web

### DIFF
--- a/providers/typekit.php
+++ b/providers/typekit.php
@@ -146,17 +146,7 @@ class Jetpack_Typekit_Font_Provider extends Jetpack_Font_Provider {
 	}
 
 	public function get_kit_id() {
-		// There was a period after the WP 4.4 deploy in [129468] and [129707] where
-		// users with an existing Typekit kit_id who removed all typekit fonts would have an orphaned
-		// kit, leading to 1) 404 calls to the kit on the frontend and 2) inability to later publish
-		// a kit, since it would attempt to add to a now-deleted kit on Typekit servers
-		$kit_id = $this->get( 'kit_id' );
-		if ( $kit_id && ! $this->any_typekit_fonts_set() ) {
-			$this->delete( 'kit_id' );
-			$kit_id = false;
-			bump_stats_extras( 'typekit-delete-orphaned-kit' );
-		}
-		return $kit_id;
+		return $this->get( 'kit_id' );
 	}
 
 	private function any_typekit_fonts_set() {

--- a/theme-support.php
+++ b/theme-support.php
@@ -418,7 +418,13 @@ class Typekit_Theme_Support {
 
 		if ( get_subscription( $purchase_meta['blog_id'], 0, WPCOM_CUSTOM_DESIGN_PRODUCT ) ) {
 			// Extend sub to expire one year from today, if it expires earlier
-			WPCOM_Store::renew( $purchase_meta['blog_id'], $purchase_meta['user_id'], WPCOM_CUSTOM_DESIGN_PRODUCT, $purchase_meta['txn_id'], $message );
+			WPCOM_Store::renew_wpcom_subscriptions( [
+				'blog_id' => $purchase_meta['blog_id'],
+				'user_id' => $purchase_meta['user_id'],
+				'product_id' => WPCOM_CUSTOM_DESIGN_PRODUCT,
+				'txn_id' => $purchase_meta['txn_id'],
+				'message' => $message
+			] );
 
 			bump_stats_extra( 'cd-typekit-free-year-bump', $stylesheet );
 		} else {

--- a/typekit-api.php
+++ b/typekit-api.php
@@ -462,7 +462,7 @@ class TypekitApi {
 		// Send error report.
 		if ( '404' != $error_code ) {
 			wp_mail(
-				'wiebe@automattic.com',
+				'wiebe@automattic.com, payton@automattic.com',
 				'TypekitAPI error',
 				$error_payload
 			);


### PR DESCRIPTION
And introduce Skolar Latin, its replacement.

https://customfontsp2.wordpress.com/2016/04/25/upcoming-updates-to-typekits-skolar-web-and-modesto-web-families/
