### PR TITLE
Move theme compatability filter to custom font plugin

### DIFF
--- a/custom-fonts-typekit.php
+++ b/custom-fonts-typekit.php
@@ -47,7 +47,6 @@ class Jetpack_Fonts_Typekit {
 	public static $republish_kit_on_shutdown = false;
 
 	public static function init() {
-		require_once __DIR__ . '/annotation-compat.php';
 		add_action( 'customize_register', array( __CLASS__, 'maybe_override_for_advanced_mode' ), 20 );
 		add_action( 'jetpack_fonts_register', array( __CLASS__, 'register_provider' ) );
 		add_action( 'customize_controls_print_scripts', array( __CLASS__, 'enqueue_scripts' ) );


### PR DESCRIPTION
The `custom-font-typekit` plugin is largely unused after sunsetting the typekit fonts, except for an annotations compatibility filter that is used by some themes. It converts existing typekit based font annotations within themes for compatibility with with new custom fonts.

This diff removes reference to the old filter in preparation for the complete removal of `custom-font-typekit`.

It works in conjunction with https://github.com/Automattic/custom-fonts/pull/317 which adds the filter into `custom-fonts`.

Note: A typekit-theme-mock.php file already existed in the custom-font plugin but was unused. It was deleted and replaced with the file from custom-font-typekit; the diff shows the difference between the two.

### Test:
- Check out this PR locally as well as https://github.com/Automattic/custom-fonts/pull/317
- Using a test site with the Adaline theme, go to the Customizer and verify that the page loads
- Test selecting/saving new fonts

Fixes: Fixes https://github.com/Automattic/view-design/issues/114