### PR TITLE
Remove `"autoload"` in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/custom-fonts-typekit",
-  "version": "v1.0.8",
+  "version": "v2.0.0",
   "require-dev": {
     "10up/wp_mock": "dev-master"
   }


### PR DESCRIPTION
The plugin should be manually loaded by the caller. `"autoload"` causes other Composer dependencies to explode:

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/36432/235516265-88ef107b-696e-472a-bd49-11c489f50591.png">

See https://github.com/Automattic/wpcomsh/actions/runs/4854174981/jobs/8651213500?pr=1366
Related https://github.com/Automattic/wpcomsh/issues/1284
Related https://github.com/Automattic/wpcomsh/pull/1366