### PR TITLE
Remove customizer: Custom Fonts Typekit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 vendor
 .env
+.idea

--- a/custom-fonts-typekit.php
+++ b/custom-fonts-typekit.php
@@ -285,7 +285,17 @@ EMBED;
 	}
 }
 
-add_action( 'setup_theme', array( 'Jetpack_Fonts_Typekit', 'init' ), 9 );
+/**
+ * Determines if we should register Custom Fonts Typekit in WordPress based on if the active
+ * theme supports blocks or not, and if the active theme has a ruleset applied.
+ */
+if ( function_exists( 'add_action' ) ) {
+	if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() && Jetpack_Fonts::get_instance()->get_rules() ) {
+		add_action( 'setup_theme', array( 'Jetpack_Fonts_Typekit', 'init' ), 9 );
+	} elseif ( ! function_exists( 'wp_is_block_theme' ) ) {
+		add_action( 'setup_theme', array( 'Jetpack_Fonts_Typekit', 'init' ), 9 );
+	}
+}
 
 // Hey wp-cli is fun
 if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
We're working on removing the customizer links from the menus. Right now core logic has changed so that we only show the links if the theme isn't block-based or if there are customize_register actions hooked.

The Custom Fonts Typekit plugin registers the aforementioned hook even if it won't be used. This PR is intended to only hook the plugin when necessary.

I've also excluded the `.idea` folder from the repo.

----WIP
