### PR TITLE
General: avoid PHP 8.2 deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "automattic/custom-fonts-typekit",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "require-dev": {
     "10up/wp_mock": "dev-master"
   }

--- a/custom-fonts-typekit.php
+++ b/custom-fonts-typekit.php
@@ -3,7 +3,7 @@
 Plugin Name: Custom Fonts Typekit
 Plugin URI: http://automattic.com/
 Description: Adds a Typekit provider to the custom-fonts plugin
-Version: 2.0.1
+Version: 2.0.2
 License: GPL2+
 Author: Automattic
 Author URI: http://automattic.com/

--- a/providers/typekit.php
+++ b/providers/typekit.php
@@ -53,6 +53,12 @@ class Jetpack_Typekit_Font_Provider extends Jetpack_Font_Provider {
 	);
 
 	/**
+	 * The Jetpack Fonts manager instance.
+	 * @var Jetpack_Fonts
+	 */
+	public $manager;
+
+	/**
 	 * Constructor
 	 * @param Jetpack_Fonts $custom_fonts Manager instance
 	 */


### PR DESCRIPTION
This should fix this problem:
PHP Deprecated:  Creation of dynamic property Jetpack_Typekit_Font_Provider::$manager is deprecated in /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1743534357.g9c932d1/vendor/automattic/custom-fonts-typekit/providers/typekit.php on line 61
